### PR TITLE
FO  Don't display shipping method for virtual cart

### DIFF
--- a/themes/classic/templates/checkout/_partials/order-final-summary.tpl
+++ b/themes/classic/templates/checkout/_partials/order-final-summary.tpl
@@ -56,6 +56,7 @@
     </div>
   </div>
 
+{if !$cart.is_virtual}
   <div class="row">
     <div class="col-md-12">
       <h4 class="h4">
@@ -87,6 +88,7 @@
       </div>
     </div>
   </div>
+{/if}
 
   <div class="row">
     {block name='order_confirmation_table'}


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you have virtual cart, the shipping method is display in payment section, if you have "Enable final summary"
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL.
| How to test?  | 
1 Bo > Preference > Order, check "Enable final summary"
2 Buy a virtual product
3 In payment section you see the shipping method section
